### PR TITLE
Switched over to use roleArn on annotation due to cross account support

### DIFF
--- a/src/K8sJanitor.WebApi.IntegrationTests/Repositories/Kubernetes/NamespaceRepositoryFacts.cs
+++ b/src/K8sJanitor.WebApi.IntegrationTests/Repositories/Kubernetes/NamespaceRepositoryFacts.cs
@@ -146,7 +146,7 @@ namespace K8sJanitor.WebApi.IntegrationTests.Repositories.Kubernetes
         {
             // Arrange
             var namespaceName = "namespace-from-test";
-            var awsRoleName = "awsRoleName";
+            var awsRoleName = "arn:aws:iam::528563840976:role/eks-donald-servicebroker";
             var config = KubernetesClientConfiguration.BuildConfigFromConfigFile();
             var client = new k8s.Kubernetes(config);
 

--- a/src/K8sJanitor.WebApi.Tests/EventHandlers/ContextAccountCreatedDomainEventHandlerFacts.cs
+++ b/src/K8sJanitor.WebApi.Tests/EventHandlers/ContextAccountCreatedDomainEventHandlerFacts.cs
@@ -59,10 +59,13 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             Assert.NotEmpty(configMapServiceSpy.Roles.Single().Key);
             Assert.NotEmpty(configMapServiceSpy.Roles.Single().Value);
 
-            var namespaceName = namespaceRepositorySpy.Namespaces.Single().NamespaceName;
+            var @namespace = namespaceRepositorySpy.Namespaces.Single();
+            var namespaceName = @namespace.NamespaceName;
+            
             Assert.NotNull(namespaceName);
             
             Assert.Equal(contextAccountCreatedDomainEventData.CapabilityRootId, namespaceName);
+            Assert.Equal(roleArn, @namespace.Annotations["iam.amazonaws.com/permitted"]);
 
             Assert.Equal(namespaceName,roleRepositorySpy.Namespaces.Single());
 
@@ -70,6 +73,7 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             Assert.Equal(namespaceName + "-full-access-role",
                 roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item2);
             Assert.Equal(namespaceName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item3);
+            
         }
     }
 }

--- a/src/K8sJanitor.WebApi/EventHandlers/ContextAccountCreatedDomainEventHandler.cs
+++ b/src/K8sJanitor.WebApi/EventHandlers/ContextAccountCreatedDomainEventHandler.cs
@@ -71,7 +71,7 @@ namespace K8sJanitor.WebApi.EventHandlers
                 roleName: roleName,
                 roleArn: roleArn
             );
-            var annotations = new Dictionary<string, string> {{"iam.amazonaws.com/permitted", roleName}};
+            var annotations = new Dictionary<string, string> {{"iam.amazonaws.com/permitted", roleArn}};
             await _namespaceRepository.AddAnnotations(namespaceName, annotations);
         } 
     }


### PR DESCRIPTION
In order to support cross account IAM Role assumption, we need to annotate the namespace with roleArn and not just role.