### PR TITLE
Add log.warning when using event classes we believe are deprecated.

### DIFF
--- a/src/K8sJanitor.WebApi.IntegrationTests/Repositories/Kubernetes/NamespaceRepositoryFacts.cs
+++ b/src/K8sJanitor.WebApi.IntegrationTests/Repositories/Kubernetes/NamespaceRepositoryFacts.cs
@@ -130,7 +130,7 @@ namespace K8sJanitor.WebApi.IntegrationTests.Repositories.Kubernetes
                 };
 
                 // Act / Assert
-           Assert.ThrowsAsync<Exception>(async () => await sut.AddAnnotations(namespaceName, annotationsRoundTwo));
+                await Assert.ThrowsAsync<Exception>(async () => await sut.AddAnnotations(namespaceName, annotationsRoundTwo));
             }
             finally
             {

--- a/src/K8sJanitor.WebApi/Controllers/EventsController.cs
+++ b/src/K8sJanitor.WebApi/Controllers/EventsController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using K8sJanitor.WebApi.Infrastructure.Messaging;
 using Microsoft.AspNetCore.Mvc;
+using Serilog;
 
 namespace K8sJanitor.WebApi.Controllers
 {
@@ -18,7 +19,7 @@ namespace K8sJanitor.WebApi.Controllers
         public async Task AddEvent([FromBody] Newtonsoft.Json.Linq.JObject jObject)
         {
             var eventJson = jObject.ToString(Newtonsoft.Json.Formatting.None);
-
+            Log.Warning("Deprecated call to /api/events with contents {eventJson}", eventJson);
             await _eventDispatcher.Send(eventJson);
         }
     }

--- a/src/K8sJanitor.WebApi/Domain/Events/CapabilityRegisteredDomainEvent.cs
+++ b/src/K8sJanitor.WebApi/Domain/Events/CapabilityRegisteredDomainEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace K8sJanitor.WebApi.Domain.Events
 {
@@ -18,7 +19,7 @@ namespace K8sJanitor.WebApi.Domain.Events
             XCorrelationId = domainEvent.XCorrelationId;
             XSender = domainEvent.XSender;
             Payload = (domainEvent.Payload as JObject)?.ToObject<CapabilityRegisteredDomainEventData>();
-     
+            Log.Warning("Instantiating deprecated {Type} with data {Data} ", this.GetType().FullName, Payload);
         }
     }
 


### PR DESCRIPTION
…need to followed up by removing code dealing with this event. Also fix compile warning.