### PR TITLE
Add roles and rolebindings permission to new capabilities

### DIFF
--- a/k8s/permissions.yml
+++ b/k8s/permissions.yml
@@ -20,7 +20,7 @@ metadata:
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
-  verbs: ["create"]
+  verbs: ["*"]
 - apiGroups: ["","extensions","apps"]
   resources: ["*"]
   verbs: ["*"]

--- a/src/K8sJanitor.WebApi.Tests/EventHandlers/ContextAccountCreatedDomainEventHandlerFacts.cs
+++ b/src/K8sJanitor.WebApi.Tests/EventHandlers/ContextAccountCreatedDomainEventHandlerFacts.cs
@@ -35,7 +35,7 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
 
             var @event = new ContextAccountCreatedDomainEventBuilder().Build();
 
-          
+
             // Act
             await sut.HandleAsync(@event);
 
@@ -46,22 +46,22 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
 
             var @namespace = namespaceRepositorySpy.Namespaces.Single();
             var namespaceName = @namespace.NamespaceName;
-            
-            Assert.NotNull(namespaceName);
-            
-            Assert.Equal(@event.Payload.CapabilityRootId, namespaceName);
-            Assert.Equal(IAM.ConstructRoleArn(@event.Payload.AccountId, "*"), @namespace.Annotations["iam.amazonaws.com/permitted"]);
 
-            Assert.Equal(namespaceName,roleRepositorySpy.Namespaces.Single());
+            Assert.NotNull(namespaceName);
+
+            Assert.Equal(@event.Payload.CapabilityRootId, namespaceName);
+            Assert.Equal(IAM.ConstructRoleArn(@event.Payload.AccountId, ".*"), @namespace.Annotations["iam.amazonaws.com/permitted"]);
+
+            Assert.Equal(namespaceName, roleRepositorySpy.Namespaces.Single());
 
             Assert.Equal(namespaceName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item1);
             Assert.Equal(namespaceName + "-full-access-role",
                 roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item2);
             Assert.Equal(namespaceName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item3);
-            
+
         }
-        
-        
+
+
         [Fact]
         public async Task HandleAsync_Will_Act_Idempotent_When_Namespace_Already_Exist()
         {
@@ -92,8 +92,8 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             var namespaceName = configMapServiceSpy.Roles.Single().Key;
 
             //Assert.Equal(@event.Payload.RoleArn, @namespace.Annotations["iam.amazonaws.com/permitted"]);
-//
-            Assert.Equal(namespaceName,roleRepositorySpy.Namespaces.Single());
+            //
+            Assert.Equal(namespaceName, roleRepositorySpy.Namespaces.Single());
             Assert.Equal(namespaceName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item1);
             Assert.Equal(namespaceName + "-full-access-role",
               roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item2);
@@ -101,10 +101,10 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             Assert.Equal(namespaceName, k8sAppService.Payload_Namespace);
             Assert.Equal(@event.Payload.ContextId, k8sAppService.Payload_ContextId);
             Assert.Equal(@event.Payload.CapabilityId, k8sAppService.Payload_CapabilityId);
-            
+
         }
-        
-         [Fact]
+
+        [Fact]
         public async Task HandleAsync_Will_Act_Idempotent_When_Role_Already_Exist()
         {
             // Arrange
@@ -133,14 +133,14 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             var namespaceName = configMapServiceSpy.Roles.Single().Key;
 
             Assert.Equal(namespaceName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item1);
-            Assert.Equal(roleName,roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item2);
+            Assert.Equal(roleName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item2);
             Assert.Equal(namespaceName, roleBindingRepositorySpy.NamespaceRoleToGroupBindings.Single().Item3);
             Assert.Equal(namespaceName, k8sAppService.Payload_Namespace);
             Assert.Equal(@event.Payload.ContextId, k8sAppService.Payload_ContextId);
             Assert.Equal(@event.Payload.CapabilityId, k8sAppService.Payload_CapabilityId);
-            
+
         }
-        
+
         [Fact]
         public async Task HandleAsync_Will_Act_Idempotent_When_RoleBinding_Already_Exist()
         {
@@ -148,7 +148,7 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             var configMapServiceSpy = new ConfigMapServiceSpy();
             var namespaceRepositorySpy = new NamespaceRepositorySpy();
             var roleRepositorySpy = new RoleRepositorySpy();
-            var roleBindingRepositorySpy = new ErrornousRoleBindingRepository(new RoleBindingAlreadyExistInNamespaceException("RoleBinding exists","",""));
+            var roleBindingRepositorySpy = new ErrornousRoleBindingRepository(new RoleBindingAlreadyExistInNamespaceException("RoleBinding exists", "", ""));
             var k8sAppService = new K8sApplicationServiceSpy();
             var logger = new LoggerFactory().CreateLogger<ContextAccountCreatedDomainEventHandler>();
             var sut = new ContextAccountCreatedDomainEventHandler(
@@ -166,9 +166,9 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
             await sut.HandleAsync(@event);
         }
     }
-    
-    
-    
+
+
+
 
     public class ContextAccountCreatedDomainEventBuilder
     {
@@ -196,11 +196,11 @@ namespace K8sJanitor.WebApi.Tests.EventHandlers
                     JObject.FromObject(contextAccountCreatedDomainEventData)
                 );
 
-            
-            
+
+
             return new ContextAccountCreatedDomainEvent(generalDomainEvent);
         }
-        
-        
+
+
     }
 }

--- a/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
+++ b/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
@@ -49,16 +49,11 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-<<<<<<< HEAD
                 .Throws(new HttpOperationException
                 {
                     Response =
                     new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = HttpStatusCode.Conflict }, "")
                 });
-=======
-                .Throws(new HttpOperationException{ Response =
-                    new HttpResponseMessageWrapper(new HttpResponseMessage{StatusCode = HttpStatusCode.Conflict},"")});
->>>>>>> Altering tests to match changes
 
             var @namespace = "fancyNamespace";
 
@@ -76,16 +71,11 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-<<<<<<< HEAD
                 .Throws(new HttpOperationException
                 {
                     Response =
                     new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = HttpStatusCode.BadGateway }, "Unable to communicate")
                 });
-=======
-                .Throws(new HttpOperationException{ Response =
-                    new HttpResponseMessageWrapper(new HttpResponseMessage{StatusCode = HttpStatusCode.BadGateway},"Unable to communicate")});
->>>>>>> Altering tests to match changes
 
             var @namespace = "fancyNamespace";
 
@@ -93,11 +83,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
 
         }
 
-<<<<<<< HEAD
     }
-=======
-}
->>>>>>> Altering tests to match changes
 
 
 }

--- a/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
+++ b/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
@@ -49,11 +49,16 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+<<<<<<< HEAD
                 .Throws(new HttpOperationException
                 {
                     Response =
                     new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = HttpStatusCode.Conflict }, "")
                 });
+=======
+                .Throws(new HttpOperationException{ Response =
+                    new HttpResponseMessageWrapper(new HttpResponseMessage{StatusCode = HttpStatusCode.Conflict},"")});
+>>>>>>> Altering tests to match changes
 
             var @namespace = "fancyNamespace";
 
@@ -71,11 +76,16 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+<<<<<<< HEAD
                 .Throws(new HttpOperationException
                 {
                     Response =
                     new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = HttpStatusCode.BadGateway }, "Unable to communicate")
                 });
+=======
+                .Throws(new HttpOperationException{ Response =
+                    new HttpResponseMessageWrapper(new HttpResponseMessage{StatusCode = HttpStatusCode.BadGateway},"Unable to communicate")});
+>>>>>>> Altering tests to match changes
 
             var @namespace = "fancyNamespace";
 
@@ -83,7 +93,11 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
 
         }
 
+<<<<<<< HEAD
     }
+=======
+}
+>>>>>>> Altering tests to match changes
 
 
 }

--- a/src/K8sJanitor.WebApi/EventHandlers/ContextAccountCreatedDomainEventHandler.cs
+++ b/src/K8sJanitor.WebApi/EventHandlers/ContextAccountCreatedDomainEventHandler.cs
@@ -42,7 +42,7 @@ namespace K8sJanitor.WebApi.EventHandlers
         public async Task HandleAsync(ContextAccountCreatedDomainEvent domainEvent)
         {
             var namespaceName = NamespaceName.Create(domainEvent.Payload.CapabilityRootId);
-            
+
             await CreateNameSpace(namespaceName, domainEvent);
 
             await ConnectAwsArnToNameSpace(namespaceName, domainEvent.Payload.RoleArn);
@@ -111,7 +111,7 @@ namespace K8sJanitor.WebApi.EventHandlers
             {
                 {
                     "iam.amazonaws.com/permitted",
-                    IAM.ConstructRoleArn(domainEvent.Payload.AccountId, "*")
+                    IAM.ConstructRoleArn(domainEvent.Payload.AccountId, ".*")
                 }
             });
         }

--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -61,6 +61,21 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                             "*"
                         }
                     },
+                    {
+                        ApiGroups = new List<string>
+                        {
+                            "rbac.authorization.k8s.io"
+                        },
+                        Resources = new List<string>
+                        {
+                            "rolebindings",
+                            "roles"
+                        },
+                        Verbs = new List<string>
+                        {
+                            "*"
+                        }
+                    },                    
                     new V1PolicyRule
                     {
                         ApiGroups = new List<string>

--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -61,6 +61,7 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                             "*"
                         }
                     },
+                    new V1PolicyRule
                     {
                         ApiGroups = new List<string>
                         {
@@ -75,7 +76,7 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                         {
                             "*"
                         }
-                    },                    
+                    },
                     new V1PolicyRule
                     {
                         ApiGroups = new List<string>
@@ -166,7 +167,7 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
 
                 return result?.Metadata?.Name;
             }
-            catch (HttpOperationException e) when(e.Response.StatusCode == HttpStatusCode.Conflict)
+            catch (HttpOperationException e) when (e.Response.StatusCode == HttpStatusCode.Conflict)
             {
                 throw new RoleAlreadyExistException($"Role with name {roleName} already exist in kubernetes. Not creating.", roleName);
             }


### PR DESCRIPTION
Add permissions to "roles" and "rolebindings" to new capabilities.

Cannot create role with "*" verb (for roles and rolebindings), when service account only has "create". So updated k8s-janitor permissions to "roles" and "rolebindings" resources to "*".