### PR TITLE
Enable metrics.k8s.io for pods for capabilities

### DIFF
--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -143,7 +143,24 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                             "list",
                             "watch"
                         }
-                    }
+                    },
+                    new V1PolicyRule
+                    {
+                        ApiGroups = new List<string>
+                        {
+                            "metrics.k8s.io"
+                        },
+                        Resources = new List<string>
+                        {
+                            "pods"
+                        },
+                        Verbs = new List<string>
+                        {
+                            "get",
+                            "list",
+                            "watch"
+                        }
+                    },
                 }
             };
             try


### PR DESCRIPTION
In order for teams to set the right request and limits on deployments, they need easy access to the metrics API.