### PR TITLE
Users/emcla/update kubernetes client library

### DIFF
--- a/src/K8sJanitor.WebApi.IntegrationTests/Repositories/Kubernetes/RoleRepository/CreateNamespaceFullAccessRoleFacts.cs
+++ b/src/K8sJanitor.WebApi.IntegrationTests/Repositories/Kubernetes/RoleRepository/CreateNamespaceFullAccessRoleFacts.cs
@@ -12,6 +12,7 @@ namespace K8sJanitor.WebApi.IntegrationTests.Repositories.Kubernetes.RoleReposit
     // Reads as RoleRepository.CreateNamespaceFullAccessRole can
     public class CreateNamespaceFullAccessRoleFacts
     {
+        // This test breaks if it is used in a cluster where roles are created automatically in a namespace(e.g. having Crossplane running)
         [FactRunsOnK8s]
         public async Task Create_A_Role_For_A_Existing_Namespace()
         {

--- a/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
+++ b/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
@@ -36,7 +36,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
                     r.Metadata.NamespaceProperty == @namespace &&
                     r.Rules.Count > 0 &&
                     r.Rules.Count(rule => rule.Resources.Any(res => res.Contains("namespace"))) == 1),
-                It.Is<string>(n => n == @namespace), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
+                It.Is<string>(n => n == @namespace), null, It.IsAny<CancellationToken>()));
         }
 
 
@@ -48,7 +48,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
             var sut = new RoleRepository(k8s);
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new HttpOperationException
                 {
                     Response =
@@ -56,9 +56,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
                 });
 
             var @namespace = "fancyNamespace";
-
             await Assert.ThrowsAsync<RoleAlreadyExistException>(() => sut.CreateNamespaceFullAccessRole(@namespace));
-
         }
 
 
@@ -70,7 +68,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
             var sut = new RoleRepository(k8s);
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new HttpOperationException
                 {
                     Response =

--- a/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
+++ b/src/K8sJanitor.WebApi.Tests/Repositories/Kubernetes/RoleRepositoryFacts.cs
@@ -25,7 +25,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
             var sut = new RoleRepository(k8s);
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns(() => Task.FromResult(new V1Role()));
 
             var @namespace = "fancyNamespace";
@@ -36,7 +36,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
                     r.Metadata.NamespaceProperty == @namespace &&
                     r.Rules.Count > 0 &&
                     r.Rules.Count(rule => rule.Resources.Any(res => res.Contains("namespace"))) == 1),
-                It.Is<string>(n => n == @namespace), It.IsAny<string>(), It.IsAny<CancellationToken>()));
+                It.Is<string>(n => n == @namespace), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
         }
 
 
@@ -48,7 +48,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
             var sut = new RoleRepository(k8s);
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Throws(new HttpOperationException
                 {
                     Response =
@@ -70,7 +70,7 @@ namespace K8sJanitor.WebApi.Tests.Repositories.Kubernetes
             var sut = new RoleRepository(k8s);
 
             Mock.Get(k8s).Setup(k => k.CreateNamespacedRoleAsync(It.IsAny<V1Role>(),
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Throws(new HttpOperationException
                 {
                     Response =

--- a/src/K8sJanitor.WebApi.Tests/TestDoubles/KubernetesWrapperDummy.cs
+++ b/src/K8sJanitor.WebApi.Tests/TestDoubles/KubernetesWrapperDummy.cs
@@ -9,7 +9,7 @@ namespace K8sJanitor.WebApi.Tests.TestDoubles
 {
     public class KubernetesWrapperDummy : IKubernetesWrapper
     {
-        public Task<V1Role> CreateNamespacedRoleAsync(V1Role body, string namespaceParameter, string pretty = null,
+        public Task<V1Role> CreateNamespacedRoleAsync(V1Role body, string namespaceParameter, bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(body);
@@ -25,30 +25,29 @@ namespace K8sJanitor.WebApi.Tests.TestDoubles
             return Task.CompletedTask;
         }
 
-        public Task<V1ConfigMap> ReadNamespacedConfigMapAsync(string name, string namespaceParameter, bool? exact = null, bool? export = null,
-            string pretty = null, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<V1ConfigMap> ReadNamespacedConfigMapAsync(string name, string namespaceParameter, bool? pretty = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(new V1ConfigMap());
         }
 
-        public Task<V1Namespace> ReadNamespaceAsync(string name, bool? exact = null, bool? export = null, string pretty = null,
+        public Task<V1Namespace> ReadNamespaceAsync(string name, bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(new V1Namespace());
         }
 
-        public Task<HttpOperationResponse<V1Namespace>> PatchNamespaceWithHttpMessagesAsync(V1Patch body, string name, string pretty = null,
+        public Task<HttpOperationResponse<V1Namespace>> PatchNamespaceWithHttpMessagesAsync(V1Patch body, string name, bool? pretty = null,
             Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(new HttpOperationResponse<V1Namespace>());
         }
 
-        public Task CreateNamespaceAsync(V1Namespace body, string pretty = null, CancellationToken cancellationToken = default(CancellationToken))
+        public Task CreateNamespaceAsync(V1Namespace body, bool? pretty = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.CompletedTask;
         }
 
-        public Task<V1RoleBinding> CreateNamespacedRoleBindingAsync(V1RoleBinding body, string namespaceParameter, string pretty = null,
+        public Task<V1RoleBinding> CreateNamespacedRoleBindingAsync(V1RoleBinding body, string namespaceParameter, bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(new V1RoleBinding());

--- a/src/K8sJanitor.WebApi/Infrastructure/Messaging/KafkaConsumerHostedService.cs
+++ b/src/K8sJanitor.WebApi/Infrastructure/Messaging/KafkaConsumerHostedService.cs
@@ -74,6 +74,10 @@ namespace K8sJanitor.WebApi.Infrastructure.Messaging
                                 catch (Exception ex)
                                 {
                                     _logger.LogError($"Error consuming event. Exception message: {ex.Message}", ex);
+                                    _logger.LogError(ex.StackTrace);
+                                    _cancellationTokenSource.Cancel();
+                                    System.Environment.Exit(1);
+                                    //throw;
                                 }
                             }
                         }

--- a/src/K8sJanitor.WebApi/K8sJanitor.WebApi.csproj
+++ b/src/K8sJanitor.WebApi/K8sJanitor.WebApi.csproj
@@ -14,8 +14,9 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.3.31.6" />
     <PackageReference Include="Confluent.Kafka" Version="1.1.0" />
-    <PackageReference Include="KubernetesClient" Version="1.2.0" />
+    <PackageReference Include="KubernetesClient" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="2.2.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="2.0.0" />

--- a/src/K8sJanitor.WebApi/Repositories/AwsAuthConfigMapRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/AwsAuthConfigMapRepository.cs
@@ -63,9 +63,7 @@ namespace K8sJanitor.WebApi.Repositories
             {
                 return await _client.ReadNamespacedConfigMapAsync(
                     name: ConfigMapName,
-                    namespaceParameter: ConfigMapNamespace,
-                    exact: true,
-                    export: true
+                    namespaceParameter: ConfigMapNamespace
                 );
             }
             catch (HttpOperationException httpOperationException) when (httpOperationException.Response.StatusCode ==

--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/NamespaceRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/NamespaceRepository.cs
@@ -81,7 +81,8 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
             };
             var patch = new JsonPatchDocument<V1Namespace>();
             patch.Replace(n => n.Metadata, metadata);
-            await _client.PatchNamespaceWithHttpMessagesAsync(new V1Patch(patch), namespaceName);
+            
+            await _client.PatchNamespaceWithHttpMessagesAsync(new V1Patch(patch, V1Patch.PatchType.JsonPatch), namespaceName);
         }
         
         public async Task CreateNamespaceAsync(string namespaceName, string accountId)

--- a/src/K8sJanitor.WebApi/Wrappers/IKubernetesWrapper.cs
+++ b/src/K8sJanitor.WebApi/Wrappers/IKubernetesWrapper.cs
@@ -10,44 +10,40 @@ namespace K8sJanitor.WebApi.Wrappers
 {
     public interface IKubernetesWrapper
     {
-        Task<V1Role> CreateNamespacedRoleAsync(V1Role body, string namespaceParameter, string pretty = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<V1Role> CreateNamespacedRoleAsync(V1Role body, string namespaceParameter, bool? pretty = null, CancellationToken cancellationToken = default(CancellationToken));
         Task CreateNamespacedConfigMapAsync(V1ConfigMap body, string namespaceParameter);
         Task ReplaceNamespacedConfigMapAsync(V1ConfigMap body, string name, string namespaceParameter);
         Task<V1ConfigMap> ReadNamespacedConfigMapAsync(
             string name,
             string namespaceParameter,
-            bool? exact = null,
-            bool? export = null,
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken= default(CancellationToken)
         );
         
         Task<V1Namespace> ReadNamespaceAsync(
             string name,
-            bool? exact = null,
-            bool? export = null,
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken= default(CancellationToken)
         );
 
         Task<HttpOperationResponse<V1Namespace>> PatchNamespaceWithHttpMessagesAsync(
             V1Patch body,
             string name,
-            string pretty = null,
+            bool? pretty = null,
             Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken)
         );
 
         Task CreateNamespaceAsync(
             V1Namespace body,
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken)
         );
 
         Task<V1RoleBinding> CreateNamespacedRoleBindingAsync(
             V1RoleBinding body,
             string namespaceParameter,
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken)
         );
     }

--- a/src/K8sJanitor.WebApi/Wrappers/KubernetesWrapper.cs
+++ b/src/K8sJanitor.WebApi/Wrappers/KubernetesWrapper.cs
@@ -17,10 +17,10 @@ namespace K8sJanitor.WebApi.Wrappers
         }
 
 
-        public Task<V1Role> CreateNamespacedRoleAsync(V1Role body, string namespaceParameter, string pretty = null,
+        public Task<V1Role> CreateNamespacedRoleAsync(V1Role body, string namespaceParameter, bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _kubernetes.CreateNamespacedRoleAsync(body, namespaceParameter, pretty, cancellationToken);
+            return _kubernetes.CreateNamespacedRoleAsync(body, namespaceParameter, pretty: pretty, cancellationToken: cancellationToken);
         }
 
         public Task CreateNamespacedConfigMapAsync(V1ConfigMap body, string namespaceParameter)
@@ -36,16 +36,12 @@ namespace K8sJanitor.WebApi.Wrappers
         public async Task<V1ConfigMap> ReadNamespacedConfigMapAsync(
             string name,
             string namespaceParameter,
-            bool? exact = null,
-            bool? export = null,
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _kubernetes.ReadNamespacedConfigMapAsync(
                 name,
                 namespaceParameter,
-                exact,
-                export,
                 pretty,
                 cancellationToken
             );
@@ -53,15 +49,11 @@ namespace K8sJanitor.WebApi.Wrappers
 
         public async Task<V1Namespace> ReadNamespaceAsync(
             string name,
-            bool? exact = null,
-            bool? export = null,
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _kubernetes.ReadNamespaceAsync(
                 name,
-                exact,
-                export,
                 pretty,
                 cancellationToken
             );
@@ -71,44 +63,44 @@ namespace K8sJanitor.WebApi.Wrappers
         public async Task<HttpOperationResponse<V1Namespace>> PatchNamespaceWithHttpMessagesAsync(
             V1Patch body,
             string name,
-            string pretty = null,
+            bool? pretty = null,
             Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _kubernetes.PatchNamespaceWithHttpMessagesAsync(
                 body,
                 name,
-                pretty,
-                customHeaders,
-                cancellationToken
+                pretty: pretty,
+                customHeaders: customHeaders,
+                cancellationToken: cancellationToken
             );
         }
 
         public Task CreateNamespaceAsync(
             V1Namespace body, 
-            string pretty, 
+            bool? pretty, 
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
             return _kubernetes.CreateNamespaceAsync(
                 body, 
-                pretty, 
-                cancellationToken
+                pretty: pretty, 
+                cancellationToken: cancellationToken
             );
         }
 
         public Task<V1RoleBinding> CreateNamespacedRoleBindingAsync(
             V1RoleBinding body, 
             string namespaceParameter, 
-            string pretty = null,
+            bool? pretty = null,
             CancellationToken cancellationToken = default(CancellationToken)
         )
         {
             return _kubernetes.CreateNamespacedRoleBindingAsync(
                 body,
                 namespaceParameter,
-                pretty,
-                cancellationToken
+                pretty: pretty,
+                cancellationToken: cancellationToken
             );
         }
     }

--- a/src/K8sJanitor.WebApi/Wrappers/KubernetesWrapper.cs
+++ b/src/K8sJanitor.WebApi/Wrappers/KubernetesWrapper.cs
@@ -70,6 +70,7 @@ namespace K8sJanitor.WebApi.Wrappers
             return await _kubernetes.PatchNamespaceWithHttpMessagesAsync(
                 body,
                 name,
+                fieldManager: "k8s-janitor",
                 pretty: pretty,
                 customHeaders: customHeaders,
                 cancellationToken: cancellationToken


### PR DESCRIPTION
Attempt at fixing https://github.com/dfds/k8s-janitor/issues/48

Various changes:
- _KubernetesClient_ library bumped from 1.2.0 to 6.0.1
- Additional logging(stacktrace) when an unknown/unexpected Exception occurs during event handling as well as stops the application entirely. The additional logging should hopefully help with tracking event related issues down the road. Stopping the application should hopefully also help make us aware that there is an issue thanks to our restart alerting.

Changes explained somewhat:

- _It.IsAny<string>()_ -> _It.IsAny<bool>()_ :: This was done due to the parameter called _"pretty"_ having its typed changed from a string to a boolean
- The places where the above has been changed to a null was done due to It.IsAny not supporting when null is being returned, which is sometimes the case due to the parameter allowing null(like this: _bool? = null_)
- 