### PR TITLE
Add pod security annotations for new namespaces

### DIFF
--- a/src/K8sJanitor.WebApi/EventHandlers/ContextAccountCreatedDomainEventHandler.cs
+++ b/src/K8sJanitor.WebApi/EventHandlers/ContextAccountCreatedDomainEventHandler.cs
@@ -114,6 +114,14 @@ namespace K8sJanitor.WebApi.EventHandlers
                 {
                     "dfds-aws-account-id",
                     domainEvent.Payload.AccountId
+                },
+                {
+                    "pod-security.kubernetes.io/audit",
+                    "baseline"
+                },
+                {
+                    "pod-security.kubernetes.io/warn",
+                    "baseline"
                 }
             });
         }


### PR DESCRIPTION
For context, see issue: https://github.com/dfds/cloudplatform/issues/1542

TLDR: When a new namespace is created in Kubenetes for a Capability, add additional annotations to its metadata.