### PR TITLE
Add support for new API groups: traefik.io, external-secrets.io and monitoring.coreos.com

### DIFF
--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -221,7 +221,12 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                         },
                         Resources = new List<string>
                         {
-                            "*"
+                            "ecrauthorizationtokens",
+                            "externalsecrets",
+                            "fakes",
+                            "passwords"
+                            "secretstores",
+                            "webhooks"
                         },
                         Verbs = new List<string>
                         {

--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -224,7 +224,7 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                             "ecrauthorizationtokens",
                             "externalsecrets",
                             "fakes",
-                            "passwords"
+                            "passwords",
                             "secretstores",
                             "webhooks"
                         },

--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -202,10 +202,41 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                         ApiGroups = new List<string>
                         {
                             "traefik.containo.us",
+                            "traefik.io"
                         },
                         Resources = new List<string>
                         {
                             "*"
+                        },
+                        Verbs = new List<string>
+                        {
+                            "*"
+                        }
+                    },
+                    new V1PolicyRule
+                    {
+                        ApiGroups = new List<string>
+                        {
+                            "external-secrets.io"
+                        },
+                        Resources = new List<string>
+                        {
+                            "*"
+                        },
+                        Verbs = new List<string>
+                        {
+                            "*"
+                        }
+                    },
+                    new V1PolicyRule
+                    {
+                        ApiGroups = new List<string>
+                        {
+                            "monitoring.coreos.com"
+                        },
+                        Resources = new List<string>
+                        {
+                            "servicemonitors"
                         },
                         Verbs = new List<string>
                         {


### PR DESCRIPTION
- Traefik Ingress Controller is sunsetting its previous API in Traefik version 3
- Add support for using external-secrets.io in capability namespaces
- Add support for creating servicemonitoris in capability namespaces