### PR TITLE
Allow using druid.apache.org API in capability accounts

### DIFF
--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -248,6 +248,39 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                             "*"
                         }
                     },
+                    new V1PolicyRule
+                    {
+                        ApiGroups = new List<string>
+                        {
+                            "druid.apache.org"
+                        },
+                        Resources = new List<string>
+                        {
+                            "druids/status"
+                        },
+                        Verbs = new List<string>
+                        {
+                            "get",
+                            "patch",
+                            "update"
+                        }
+                    },
+                    new V1PolicyRule
+                    {
+                        ApiGroups = new List<string>
+                        {
+                            "druid.apache.org"
+                        },
+                        Resources = new List<string>
+                        {
+                            "druids",
+                            "druidingestions"
+                        },
+                        Verbs = new List<string>
+                        {
+                            "*"
+                        }
+                    },
                 }
             };
             try


### PR DESCRIPTION
For being aple to spin up Apache Druid clusters on Kubernetes. Requested by dataplatform. 

Issue: https://github.com/dfds/cloudplatform/issues/3050 and https://github.com/dfds/cloudplatform/issues/3048