### PR TITLE
Remove support for old Traefik API version

### DIFF
--- a/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
+++ b/src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs
@@ -201,7 +201,6 @@ namespace K8sJanitor.WebApi.Repositories.Kubernetes
                     {
                         ApiGroups = new List<string>
                         {
-                            "traefik.containo.us",
                             "traefik.io"
                         },
                         Resources = new List<string>


### PR DESCRIPTION
This pull request includes a change to the `CreateNamespaceFullAccessRole` method in the `RoleRepository.cs` file. The change updates the list of API groups that the role has access to.

* [`src/K8sJanitor.WebApi/Repositories/Kubernetes/RoleRepository.cs`](diffhunk://#diff-c285fcac366698026fe9729a0e7adedec678260d81d6b2683875b80066474f54L204): Removed the API group `"traefik.containo.us"` from the `ApiGroups` list in the `CreateNamespaceFullAccessRole` method.


Issue: https://github.com/dfds/cloudplatform/issues/3104